### PR TITLE
inherit DetectionAreaButton from UIButton instead of UIControl to fix to fix strange issue with touchUpInside event handling

### DIFF
--- a/Sources/AttributedLabel.swift
+++ b/Sources/AttributedLabel.swift
@@ -150,7 +150,7 @@ open class AttributedLabel: UIView {
     }
 
     //MARK: - DetectionAreaButton
-    private class DetectionAreaButton: UIControl {
+    private class DetectionAreaButton: UIButton {
         
         var onHighlightChanged: ((DetectionAreaButton)->Void)?
         


### PR DESCRIPTION
Due development of app we faced with strange tap handling issue. Currently it reproduces only in one place in our code, but we have no idea why.

![tap_handling_trouble](https://user-images.githubusercontent.com/6436245/49996386-eca63a80-ff9f-11e8-9c50-e0b51d6b6d56.gif)

If we enable breakpoint in `button.onHighlightChanged` closure, then `handleDetectionAreaButtonClick` is called, otherwise - not.
Also if we press link long enough it's also fixes the problem.

But people did't run apps in simulators and don't like to long tap on links.

So we ended up with following workaround: inherit `DetectionAreaButton` from `UIButton` instead of `UIControl` (since it is called DetectionArea**Button**, right? :)).
 This fixes the issue.