### PR TITLE
Fix podspec to build on Xcode 11 beta on Catalina

### DIFF
--- a/Atributika.podspec
+++ b/Atributika.podspec
@@ -14,5 +14,6 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = "2.0"
   s.tvos.deployment_target = "9.0"
   s.source       = { :git => "https://github.com/psharanda/Atributika.git", :tag => s.version.to_s }
-  s.source_files  = "Sources/**/*"
+  s.source_files = "Sources/**/*.swift"
+  s.resources    = 'Sources/*.plist'
 end


### PR DESCRIPTION
Xcode on Catalina seems to be more strict and no longer accepts plist files that should simply be copied as source files.