### PR TITLE
Preliminary SwiftUI support

### DIFF
--- a/Atributika.xcodeproj/project.pbxproj
+++ b/Atributika.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		1BDDF56B1E6841EA006374F6 /* AttributedLabelDemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BDDF56A1E6841EA006374F6 /* AttributedLabelDemoViewController.swift */; };
 		52D6D9871BEFF229002C0205 /* Atributika.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52D6D97C1BEFF229002C0205 /* Atributika.framework */; };
 		52D6D99B1BEFF375002C0205 /* AtributikaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52D6D9971BEFF375002C0205 /* AtributikaTests.swift */; };
+		947F84B1246DE4B600450042 /* AttributtedLabelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 947F84B0246DE4B600450042 /* AttributtedLabelView.swift */; };
 		DD7502861C68FDDC006590AF /* AtributikaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52D6D9971BEFF375002C0205 /* AtributikaTests.swift */; };
 		DD7502881C68FEDE006590AF /* Atributika.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52D6DA0F1BF000BD002C0205 /* Atributika.framework */; };
 		DD7502921C690C7A006590AF /* Atributika.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52D6D9F01BEFFFBE002C0205 /* Atributika.framework */; };
@@ -122,6 +123,7 @@
 		52D6D9E21BEFFF6E002C0205 /* Atributika.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Atributika.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		52D6D9F01BEFFFBE002C0205 /* Atributika.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Atributika.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		52D6DA0F1BF000BD002C0205 /* Atributika.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Atributika.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		947F84B0246DE4B600450042 /* AttributtedLabelView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttributtedLabelView.swift; sourceTree = "<group>"; };
 		AD2FAA261CD0B6D800659CF4 /* Atributika.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Atributika.plist; sourceTree = "<group>"; };
 		AD2FAA281CD0B6E100659CF4 /* AtributikaTests.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = AtributikaTests.plist; sourceTree = "<group>"; };
 		DD75027A1C68FCFC006590AF /* Atributika-macOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Atributika-macOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -195,6 +197,7 @@
 		1B2F838E1E5C98A4009AFBCA /* Demo */ = {
 			isa = PBXGroup;
 			children = (
+				947F84B0246DE4B600450042 /* AttributtedLabelView.swift */,
 				1BDDF5681E683A8F006374F6 /* Snippet.swift */,
 				1B2F83911E5C98A4009AFBCA /* SnippetsViewController.swift */,
 				1BDDF56A1E6841EA006374F6 /* AttributedLabelDemoViewController.swift */,
@@ -591,6 +594,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1B80548A23A8ACDF002DCA63 /* IBViewController.swift in Sources */,
+				947F84B1246DE4B600450042 /* AttributtedLabelView.swift in Sources */,
 				1BDDF5691E683A8F006374F6 /* Snippet.swift in Sources */,
 				1B2F83921E5C98A4009AFBCA /* SnippetsViewController.swift in Sources */,
 				1B2F83901E5C98A4009AFBCA /* AppDelegate.swift in Sources */,

--- a/Atributika.xcodeproj/project.pbxproj
+++ b/Atributika.xcodeproj/project.pbxproj
@@ -47,7 +47,7 @@
 		1BDDF56B1E6841EA006374F6 /* AttributedLabelDemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BDDF56A1E6841EA006374F6 /* AttributedLabelDemoViewController.swift */; };
 		52D6D9871BEFF229002C0205 /* Atributika.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52D6D97C1BEFF229002C0205 /* Atributika.framework */; };
 		52D6D99B1BEFF375002C0205 /* AtributikaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52D6D9971BEFF375002C0205 /* AtributikaTests.swift */; };
-		947F84B1246DE4B600450042 /* AttributtedLabelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 947F84B0246DE4B600450042 /* AttributtedLabelView.swift */; };
+		947F84B1246DE4B600450042 /* AttributedLabelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 947F84B0246DE4B600450042 /* AttributedLabelView.swift */; };
 		DD7502861C68FDDC006590AF /* AtributikaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52D6D9971BEFF375002C0205 /* AtributikaTests.swift */; };
 		DD7502881C68FEDE006590AF /* Atributika.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52D6DA0F1BF000BD002C0205 /* Atributika.framework */; };
 		DD7502921C690C7A006590AF /* Atributika.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52D6D9F01BEFFFBE002C0205 /* Atributika.framework */; };
@@ -123,7 +123,7 @@
 		52D6D9E21BEFFF6E002C0205 /* Atributika.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Atributika.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		52D6D9F01BEFFFBE002C0205 /* Atributika.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Atributika.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		52D6DA0F1BF000BD002C0205 /* Atributika.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Atributika.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		947F84B0246DE4B600450042 /* AttributtedLabelView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttributtedLabelView.swift; sourceTree = "<group>"; };
+		947F84B0246DE4B600450042 /* AttributedLabelView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttributedLabelView.swift; sourceTree = "<group>"; };
 		AD2FAA261CD0B6D800659CF4 /* Atributika.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Atributika.plist; sourceTree = "<group>"; };
 		AD2FAA281CD0B6E100659CF4 /* AtributikaTests.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = AtributikaTests.plist; sourceTree = "<group>"; };
 		DD75027A1C68FCFC006590AF /* Atributika-macOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Atributika-macOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -197,7 +197,7 @@
 		1B2F838E1E5C98A4009AFBCA /* Demo */ = {
 			isa = PBXGroup;
 			children = (
-				947F84B0246DE4B600450042 /* AttributtedLabelView.swift */,
+				947F84B0246DE4B600450042 /* AttributedLabelView.swift */,
 				1BDDF5681E683A8F006374F6 /* Snippet.swift */,
 				1B2F83911E5C98A4009AFBCA /* SnippetsViewController.swift */,
 				1BDDF56A1E6841EA006374F6 /* AttributedLabelDemoViewController.swift */,
@@ -594,7 +594,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1B80548A23A8ACDF002DCA63 /* IBViewController.swift in Sources */,
-				947F84B1246DE4B600450042 /* AttributtedLabelView.swift in Sources */,
+				947F84B1246DE4B600450042 /* AttributedLabelView.swift in Sources */,
 				1BDDF5691E683A8F006374F6 /* Snippet.swift in Sources */,
 				1B2F83921E5C98A4009AFBCA /* SnippetsViewController.swift in Sources */,
 				1B2F83901E5C98A4009AFBCA /* AppDelegate.swift in Sources */,

--- a/Demo/AttributedLabelView.swift
+++ b/Demo/AttributedLabelView.swift
@@ -1,5 +1,5 @@
 //
-//  AttributtedLabelView.swift
+//  AttributedLabelView.swift
 //  Demo
 //
 //  Created by Ernesto Rivera on 5/14/20.
@@ -10,7 +10,7 @@ import SwiftUI
 import Atributika
 
 @available(iOS 13.0, *)
-struct AttributtedLabelView: UIViewRepresentable
+struct AttributedLabelView: UIViewRepresentable
 {
     var attributedText: AttributedText?
     var configureLabel: ((AttributedLabel) -> Void)? = nil
@@ -60,21 +60,21 @@ struct AttributtedLabelView_Previews: PreviewProvider
         
         return GeometryReader { geometry in
             List {
-                AttributtedLabelView(attributedText: "Denny JA: Dengan RT ini, anda ikut memenangkan Jokowi-JK. Pilih pemimpin yg bisa dipercaya (Jokowi) dan pengalaman (JK). #DJoJK"
+                AttributedLabelView(attributedText: "Denny JA: Dengan RT ini, anda ikut memenangkan Jokowi-JK. Pilih pemimpin yg bisa dipercaya (Jokowi) dan pengalaman (JK). #DJoJK"
                     .style(tags: link)
                     .styleHashtags(link)
                     .styleMentions(link)
                     .styleLinks(link)
                     .styleAll(all), configureLabel: configureLabel, maxWidth: geometry.size.width)
                     .fixedSize(horizontal: true, vertical: true)
-                AttributtedLabelView(attributedText: "@e2F If only Bradley's arm was longer. Best photo ever. 😊 #oscars https://pic.twitter.com/C9U5NOtGap<br>Check this <a href=\"https://github.com/psharanda/Atributika\">link</a>"
+                AttributedLabelView(attributedText: "@e2F If only Bradley's arm was longer. Best photo ever. 😊 #oscars https://pic.twitter.com/C9U5NOtGap<br>Check this <a href=\"https://github.com/psharanda/Atributika\">link</a>"
                     .style(tags: link)
                     .styleHashtags(link)
                     .styleMentions(link)
                     .styleLinks(link)
                     .styleAll(all), configureLabel: configureLabel)
                     .fixedSize(horizontal: true, vertical: true)
-                AttributtedLabelView(attributedText: """
+                AttributedLabelView(attributedText: """
                 # A big message
 
                 - With *mentions* [Ernesto Test Account](user://91010061)

--- a/Demo/AttributtedLabelView.swift
+++ b/Demo/AttributtedLabelView.swift
@@ -13,6 +13,7 @@ import Atributika
 struct AttributtedLabelView: UIViewRepresentable
 {
     var attributedText: AttributedText?
+    var configureLabel: ((AttributedLabel) -> Void)? = nil
     
     @State var maxWidth: CGFloat = 300
     
@@ -21,15 +22,14 @@ struct AttributtedLabelView: UIViewRepresentable
     func makeUIView(context: Context) -> MaxWidthAttributedLabel
     {
         let view = MaxWidthAttributedLabel()
-        view.numberOfLines = 0
-        view.textColor = .label
+        configureLabel?(view)
         return view
     }
     
     func updateUIView(_ uiView: MaxWidthAttributedLabel, context: Context)
     {
-        uiView.attributedText = self.attributedText
-        uiView.maxWidth = self.maxWidth
+        uiView.attributedText = attributedText
+        uiView.maxWidth = maxWidth
     }
     
     class MaxWidthAttributedLabel: AttributedLabel
@@ -38,7 +38,7 @@ struct AttributtedLabelView: UIViewRepresentable
         
         open override var intrinsicContentSize: CGSize
         {
-            self.sizeThatFits(CGSize(width: self.maxWidth, height: .infinity))
+            sizeThatFits(CGSize(width: maxWidth, height: .infinity))
         }
     }
 }
@@ -53,41 +53,47 @@ struct AttributtedLabelView_Previews: PreviewProvider
         let link = Style("a")
             .foregroundColor(.blue, .normal)
             .foregroundColor(.brown, .highlighted)
+        let configureLabel: ((AttributedLabel) -> Void) = { label in
+            label.numberOfLines = 0
+            label.textColor = .label
+        }
         
-        return List {
-            AttributtedLabelView(attributedText: "Denny JA: Dengan RT ini, anda ikut memenangkan Jokowi-JK. Pilih pemimpin yg bisa dipercaya (Jokowi) dan pengalaman (JK). #DJoJK"
-                .style(tags: link)
-                .styleHashtags(link)
-                .styleMentions(link)
-                .styleLinks(link)
-                .styleAll(all))
-                .fixedSize(horizontal: true, vertical: true)
-            AttributtedLabelView(attributedText: "@e2F If only Bradley's arm was longer. Best photo ever. 😊 #oscars https://pic.twitter.com/C9U5NOtGap<br>Check this <a href=\"https://github.com/psharanda/Atributika\">link</a>"
-                .style(tags: link)
-                .styleHashtags(link)
-                .styleMentions(link)
-                .styleLinks(link)
-                .styleAll(all))
-                .fixedSize(horizontal: true, vertical: true)
-            AttributtedLabelView(attributedText: """
-            # A big message
+        return GeometryReader { geometry in
+            List {
+                AttributtedLabelView(attributedText: "Denny JA: Dengan RT ini, anda ikut memenangkan Jokowi-JK. Pilih pemimpin yg bisa dipercaya (Jokowi) dan pengalaman (JK). #DJoJK"
+                    .style(tags: link)
+                    .styleHashtags(link)
+                    .styleMentions(link)
+                    .styleLinks(link)
+                    .styleAll(all), configureLabel: configureLabel, maxWidth: geometry.size.width)
+                    .fixedSize(horizontal: true, vertical: true)
+                AttributtedLabelView(attributedText: "@e2F If only Bradley's arm was longer. Best photo ever. 😊 #oscars https://pic.twitter.com/C9U5NOtGap<br>Check this <a href=\"https://github.com/psharanda/Atributika\">link</a>"
+                    .style(tags: link)
+                    .styleHashtags(link)
+                    .styleMentions(link)
+                    .styleLinks(link)
+                    .styleAll(all), configureLabel: configureLabel)
+                    .fixedSize(horizontal: true, vertical: true)
+                AttributtedLabelView(attributedText: """
+                # A big message
 
-            - With *mentions* [Ernesto Test Account](user://91010061)
-            - **Bold** text
+                - With *mentions* [Ernesto Test Account](user://91010061)
+                - **Bold** text
 
-            ## Also
+                ## Also
 
-            > Quotes
+                > Quotes
 
-            1. Some `code`
-            2. And data detectors  (801) 917 4444, email@dot.com and http://apple.com
-            """
-                .style(tags: link)
-                .styleHashtags(link)
-                .styleMentions(link)
-                .styleLinks(link)
-                .styleAll(all))
-                .fixedSize(horizontal: true, vertical: true)
+                1. Some `code`
+                2. And data detectors  (801) 917 4444, email@dot.com and http://apple.com
+                """
+                    .style(tags: link)
+                    .styleHashtags(link)
+                    .styleMentions(link)
+                    .styleLinks(link)
+                    .styleAll(all), configureLabel: configureLabel)
+                    .fixedSize(horizontal: true, vertical: true)
+            }
         }
     }
 }

--- a/Demo/AttributtedLabelView.swift
+++ b/Demo/AttributtedLabelView.swift
@@ -1,0 +1,95 @@
+//
+//  AttributtedLabelView.swift
+//  Demo
+//
+//  Created by Ernesto Rivera on 5/14/20.
+//  Copyright © 2020 Atributika. All rights reserved.
+//
+
+import SwiftUI
+import Atributika
+
+@available(iOS 13.0, *)
+struct AttributtedLabelView: UIViewRepresentable
+{
+    var attributedText: AttributedText?
+    
+    @State var maxWidth: CGFloat = 300
+    
+    typealias UIViewType = MaxWidthAttributedLabel
+    
+    func makeUIView(context: Context) -> MaxWidthAttributedLabel
+    {
+        let view = MaxWidthAttributedLabel()
+        view.numberOfLines = 0
+        view.textColor = .label
+        return view
+    }
+    
+    func updateUIView(_ uiView: MaxWidthAttributedLabel, context: Context)
+    {
+        uiView.attributedText = self.attributedText
+        uiView.maxWidth = self.maxWidth
+    }
+    
+    class MaxWidthAttributedLabel: AttributedLabel
+    {
+        var maxWidth: CGFloat!
+        
+        open override var intrinsicContentSize: CGSize
+        {
+            self.sizeThatFits(CGSize(width: self.maxWidth, height: .infinity))
+        }
+    }
+}
+
+#if DEBUG
+@available(iOS 13.0, *)
+struct AttributtedLabelView_Previews: PreviewProvider
+{
+    static var previews: some View
+    {
+        let all = Style.font(UIFont.preferredFont(forTextStyle: .body))
+        let link = Style("a")
+            .foregroundColor(.blue, .normal)
+            .foregroundColor(.brown, .highlighted)
+        
+        return List {
+            AttributtedLabelView(attributedText: "Denny JA: Dengan RT ini, anda ikut memenangkan Jokowi-JK. Pilih pemimpin yg bisa dipercaya (Jokowi) dan pengalaman (JK). #DJoJK"
+                .style(tags: link)
+                .styleHashtags(link)
+                .styleMentions(link)
+                .styleLinks(link)
+                .styleAll(all))
+                .fixedSize(horizontal: true, vertical: true)
+            AttributtedLabelView(attributedText: "@e2F If only Bradley's arm was longer. Best photo ever. 😊 #oscars https://pic.twitter.com/C9U5NOtGap<br>Check this <a href=\"https://github.com/psharanda/Atributika\">link</a>"
+                .style(tags: link)
+                .styleHashtags(link)
+                .styleMentions(link)
+                .styleLinks(link)
+                .styleAll(all))
+                .fixedSize(horizontal: true, vertical: true)
+            AttributtedLabelView(attributedText: """
+            # A big message
+
+            - With *mentions* [Ernesto Test Account](user://91010061)
+            - **Bold** text
+
+            ## Also
+
+            > Quotes
+
+            1. Some `code`
+            2. And data detectors  (801) 917 4444, email@dot.com and http://apple.com
+            """
+                .style(tags: link)
+                .styleHashtags(link)
+                .styleMentions(link)
+                .styleLinks(link)
+                .styleAll(all))
+                .fixedSize(horizontal: true, vertical: true)
+        }
+    }
+}
+#endif
+


### PR DESCRIPTION
For now an `AttributtedLabel` SwiftUI wrapper in the Demo project that allows full customization using an optional `configureLabel` block property.

Usage requires to set a `maxWidth` (default value `300`) and requires adding the `.fixedSize(horizontal: true, vertical: true)` modifier:

```swift
AttributedLabelView(attributedText: "Denny JA: Dengan RT ini, anda ikut memenangkan Jokowi-JK. Pilih pemimpin yg bisa dipercaya (Jokowi) dan pengalaman (JK). #DJoJK"
    .style(tags: link)
    .styleHashtags(link)
    .styleMentions(link)
    .styleLinks(link)
    .styleAll(all), configureLabel: configureLabel, maxWidth: geometry.size.width)
    .fixedSize(horizontal: true, vertical: true)
```

Related to #103 and #113.