### PR TITLE
Convert Substring to String To Fix Xcode 12 Compilation Failure

### DIFF
--- a/Sources/HTMLSpecials.swift
+++ b/Sources/HTMLSpecials.swift
@@ -11,7 +11,7 @@ extension String {
         let radix = isHexadecimal ? 16 : 10
         
         let numberStartIndex = index(startIndex, offsetBy: isHexadecimal ? 1 : 0)
-        let numberString = self[numberStartIndex ..< endIndex]
+        let numberString = String(self[numberStartIndex ..< endIndex])
         
         guard let codePoint = UInt32(numberString, radix: radix),
             let scalar = UnicodeScalar(codePoint) else {


### PR DESCRIPTION
Xcode 12 fails to archive on 4.9.7. This fixes the issue.