### PR TITLE
Fix infinite loop when using `<` or `&` characters with diacritic

### DIFF
--- a/Sources/NSScanner+Swift.swift
+++ b/Sources/NSScanner+Swift.swift
@@ -36,6 +36,20 @@ extension Scanner {
         return nil
     }
     
+    /// Returns the given string if scanned, or `nil` if not found.
+    @discardableResult func scanString(_ str: String, options: NSString.CompareOptions) -> String? {
+        let scanRange = NSRange(location: self.scanLocation, length: str.count)
+        guard scanRange.location + str.count <= self.string.count else { return nil }
+
+        let scanned = (self.string as NSString).substring(with: scanRange)
+        if (scanned.compare(str, options: options, range: nil, locale: nil) == .orderedSame) {
+            self.scanLocation += str.count
+            return str
+        } else {
+            return nil
+        }
+    }
+    
     /// Returns a string, scanned until the given string is found, or the remainder of the scanner's string. Returns `nil` if the scanner is already `atEnd`.
     func scanUpTo(_ str: String) -> String? {
         var value: NSString? = ""

--- a/Sources/String+Detection.swift
+++ b/Sources/String+Detection.swift
@@ -106,7 +106,7 @@ extension String {
             if let textString = scanner.scanUpToCharacters(from: CharacterSet(charactersIn: "<&")) {
                 resultString.append(textString)
             } else {
-                if scanner.scanString("<") != nil {
+                if scanner.scanString("<", options: .diacriticInsensitive) != nil {
                     
                     if scanner.isAtEnd {
                         resultString.append("<")
@@ -165,7 +165,7 @@ extension String {
                             resultString.append("<")
                         }
                     }
-                } else if scanner.scanString("&") != nil {
+                } else if scanner.scanString("&", options: .diacriticInsensitive) != nil {
                     if scanner.scanString("#") != nil {
                         if let potentialSpecial = scanner.scanCharacters(from: CharacterSet.alphanumerics) {
                             if scanner.scanString(";") != nil {

--- a/Tests/AtributikaTests/AtributikaTests.swift
+++ b/Tests/AtributikaTests/AtributikaTests.swift
@@ -709,6 +709,12 @@ class AtributikaTests: XCTestCase {
         XCTAssertEqual(string, test)
         XCTAssertEqual(tags.count, 0)
     }
+    
+    // sut should not encounter infinity loop when using ampersand or less than symbol character with diacritic
+    func testAmpersandOrLessThanSymbolCharacterWithDiacritic() {
+        let actual = "Hello &️ World <️ Good".detectTags()
+        XCTAssertEqual(actual.string, "Hello &️ World <️ Good")
+    }
 }
 
 


### PR DESCRIPTION
The infinite loop problem is caused by different diacritic handling policies.
`NSScanner.scanUpToCharacters(from:)` is not diacritic sensitive but `NSScanner.scanString(_:) is diacritic sensitive.