### PR TITLE
[Fixed] : Double Quote to Single Quote

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,8 +232,8 @@ Atributika is available through [CocoaPods](http://cocoapods.org). To install
 it, simply add the following line to your Podfile:
 
 ```ruby
-pod "Atributika"
-pod "AtributikaViews"
+pod 'Atributika'
+pod 'AtributikaViews'
 ```
 
 ### Manual


### PR DESCRIPTION
I changed the double quotes to single quotes in the pod "projectname" to pod 'projectname' 

The essential difference between the two literal forms of strings (single or double quotes) is that double quotes allow for escape sequences while single quotes do not!

It's not a mandatory task, but I changed it because I don't think I'll need escape sequences  when using that pod.